### PR TITLE
Abstain opinion

### DIFF
--- a/lib/scram.rb
+++ b/lib/scram.rb
@@ -1,5 +1,6 @@
 require "scram/version"
 require "mongoid"
+require "scram/core_ext/symbol_extensions.rb"
 require "scram/dsl/builders.rb"
 require "scram/dsl/definitions.rb"
 require "scram/dsl/model_conditions.rb"

--- a/lib/scram/app/models/policy.rb
+++ b/lib/scram/app/models/policy.rb
@@ -6,6 +6,8 @@ module Scram
 
     embeds_many :targets
 
+    field :priority, type: Integer, default: 0
+
     validates_presence_of :collection
 
     # @return [String] What this Policy applies to. Usually it will be the name of a Model, but it can also be a String for a "global" policy for non model-bound permissions
@@ -36,7 +38,7 @@ module Scram
     def can? holder, action, obj
       target = target.to_s if target.is_a? Symbol
       action = action.to_s if action.is_a? Symbol
-      
+
       # The following checks prevent unnecessary iteration
       if obj.is_a? String # ex: can? :view, "peek_bar"
         return false if self.model? # policy doesn't handle strings

--- a/lib/scram/app/models/policy.rb
+++ b/lib/scram/app/models/policy.rb
@@ -6,9 +6,10 @@ module Scram
 
     embeds_many :targets
 
-    field :priority, type: Integer, default: 0
-
     validates_presence_of :collection
+
+    # @return [Integer] Priority to allow this policy to override another conflicting {Scram::Policy} opinion.
+    field :priority, type: Integer, default: 0
 
     # @return [String] What this Policy applies to. Usually it will be the name of a Model, but it can also be a String for a "global" policy for non model-bound permissions
     field :collection_name, type: String

--- a/lib/scram/app/models/target.rb
+++ b/lib/scram/app/models/target.rb
@@ -54,7 +54,7 @@ module Scram
         fields_hash.each do |field, model_value|
           # Either gets the model's attribute or gets the DSL defined condition.
           # Abstains if neither can be reached
-          attribute = begin obj.send(field.to_s) rescue return :abstain end
+          attribute = begin obj.send(:"#{field}") rescue return :abstain end
 
           # Special value substitutions
           model_value.gsub! "*holder", holder.scram_compare_value if model_value.respond_to?(:gsub!)

--- a/lib/scram/concerns/aggregate_holder.rb
+++ b/lib/scram/concerns/aggregate_holder.rb
@@ -1,0 +1,20 @@
+module Scram
+  module AggregateHolder
+    include Holder
+
+    def aggregates
+      raise NotImplementedError # should be implemented by subclass
+    end
+
+    # @return [Array] list of policies
+    def policies
+      aggregate_policies = aggregates.map {|a| a.policies}.flatten.sort_by {|p| p.priority}.reverse
+    end
+
+    # @return [Object] a value to compare {AggregateHolder} in the database. For example, an ObjectID would be suitable.
+    def scram_compare_value
+      raise NotImplementedError
+    end
+
+  end
+end

--- a/lib/scram/concerns/aggregate_holder.rb
+++ b/lib/scram/concerns/aggregate_holder.rb
@@ -1,12 +1,15 @@
 module Scram
+  # Class representing a Holder of policies through other Holders
+  # @note Implementing classes must implement #aggregate, #policies and #scram_compare_value
   module AggregateHolder
     include Holder
 
+    # @return [Array] other holders to consider in Policy inclusion
     def aggregates
       raise NotImplementedError # should be implemented by subclass
     end
 
-    # @return [Array] list of policies
+    # @return [Array] list of policies through aggregates
     def policies
       aggregate_policies = aggregates.map {|a| a.policies}.flatten.sort_by {|p| p.priority}.reverse
     end

--- a/lib/scram/concerns/holder.rb
+++ b/lib/scram/concerns/holder.rb
@@ -22,7 +22,7 @@ module Scram
       target = target.to_s if target.is_a? Symbol
       action = action.to_s if action.is_a? Symbol
 
-      policies.any? {|p| p.can? self, action, target}
+      policies.sort_by{|p| p.priority}.reverse.any? {|p| p.can? self, action, target}
     end
 
 

--- a/lib/scram/concerns/holder.rb
+++ b/lib/scram/concerns/holder.rb
@@ -1,4 +1,6 @@
 module Scram
+  using SymbolExtensions
+
   # Base class to represent a Holder of permissions through policies.
   # @note Implementing classes must implement #policies and #scram_compare_value
   module Holder
@@ -17,12 +19,17 @@ module Scram
     # Checks if this holder can perform some action on an object by checking the Holder's policies
     # @param action [String] What the user is trying to do to obj
     # @param obj [Object] The receiver of the action
-    # @return [Boolean] Whether or not holder can action to object
+    # @return [Boolean] Whether or not holder can action to object. We define a full abstainment as a failure to perform the action.
     def can? action, target
       target = target.to_s if target.is_a? Symbol
-      action = action.to_s if action.is_a? Symbol
+      action = action.to_s
 
-      policies.sort_by{|p| p.priority}.reverse.any? {|p| p.can? self, action, target}
+      policies.sort_by{|p| p.priority}.reverse.each do |policy|
+        opinion = policy.can?(self, action, target)
+        return opinion.to_bool if %i[allow deny].include? opinion
+      end
+
+      return false
     end
 
 

--- a/lib/scram/concerns/holder.rb
+++ b/lib/scram/concerns/holder.rb
@@ -24,7 +24,8 @@ module Scram
       target = target.to_s if target.is_a? Symbol
       action = action.to_s
 
-      policies.sort_by{|p| p.priority}.reverse.each do |policy|
+      # Checks policies in priority order for explicit allow or deny.
+      policies.sort_by(&:priority).reverse.each do |policy|
         opinion = policy.can?(self, action, target)
         return opinion.to_bool if %i[allow deny].include? opinion
       end

--- a/lib/scram/core_ext/symbol_extensions.rb
+++ b/lib/scram/core_ext/symbol_extensions.rb
@@ -1,0 +1,14 @@
+# Refinements to the Symbol class
+module SymbolExtensions
+  refine Symbol do
+    # Converts self to a boolean if it is :allow, :abstain, :deny. Assumes that abstain means false.
+    # @return [Boolean] Boolean representation of allow, abstain, or deny. Abstain means false.
+    # @raise [NotImplementedError] If unsupported symbol is converted (not :allow, :abstain, :deny)
+    def to_bool
+      raise NotImplementedError("Cannot convert #{self} to a boolean! #to_bool only supports :allow, :abstain and :deny.") unless %i[allow abstain deny].include? self
+      return true if self == :allow
+      return false if self == :abstain
+      return false if self == :deny
+    end
+  end
+end

--- a/lib/scram/dsl/model_conditions.rb
+++ b/lib/scram/dsl/model_conditions.rb
@@ -29,7 +29,8 @@ module Scram::DSL
         condition_name = method.to_s.split("*")[1].to_sym
         conditions = self.class.scram_conditions
         if conditions && !conditions[condition_name].nil?
-          return conditions[condition_name].call(obj)
+          puts "RETURNING A CONDITION FROM MISSING"
+          return conditions[condition_name].call(self)
         end
       end
       super

--- a/lib/scram/dsl/model_conditions.rb
+++ b/lib/scram/dsl/model_conditions.rb
@@ -23,6 +23,7 @@ module Scram::DSL
       end
     end
 
+    # Methods starting with an asterisk are tested for DSL defined conditions
     def method_missing(method, *args)
       if method.to_s.starts_with? "*"
         condition_name = method.to_s.split("*")[1].to_sym
@@ -31,10 +32,10 @@ module Scram::DSL
           return conditions[condition_name].call(obj)
         end
       end
-
       super
     end
 
+    # Allow DSL condition methods to show up as methods (i.e fix #respond_to?)
     def respond_to_missing?(method, include_private = false)
       if method.to_s.starts_with? "*"
         condition_name = method.to_s.split("*")[1].to_sym

--- a/spec/scram/concerns/aggregate_holder_spec.rb
+++ b/spec/scram/concerns/aggregate_holder_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module Scram
+  describe Scram::AggregateHolder do
+    it "uses permissions from aggregates" do
+      target1 = Target.new
+      target1.actions << "woot"
+      policy1 = Policy.new
+      policy1.collection_name = TestModel.name # A misc policy for strings
+      policy1.targets << target1
+      holder1 = SimpleHolder.new(policies: [policy1])
+
+      target2 = Target.new
+      target2.actions << "donk"
+      policy2 = Policy.new
+      policy2.collection_name = TestModel.name # A misc policy for strings
+      policy2.targets << target2
+      holder2 = SimpleHolder.new(policies: [policy2])
+
+      user = SimpleAggregateHolder.new(aggregates: [holder1, holder2])
+      expect(user.can? :woot, TestModel.new).to be true
+      expect(user.can? :donk, TestModel.new).to be true
+      expect(user.can? :zing, TestModel.new).to be false
+    end
+  end
+end

--- a/spec/scram/concerns/aggregate_holder_spec.rb
+++ b/spec/scram/concerns/aggregate_holder_spec.rb
@@ -2,6 +2,13 @@ require "spec_helper"
 
 module Scram
   describe Scram::AggregateHolder do
+
+    it "cannot be used without an implementation" do
+      expect {UnimplementedAggregateHolder.new.policies}.to raise_error(NotImplementedError)
+      expect {UnimplementedAggregateHolder.new.aggregates}.to raise_error(NotImplementedError)
+      expect {UnimplementedAggregateHolder.new.scram_compare_value}.to raise_error(NotImplementedError)
+    end
+
     it "uses permissions from aggregates" do
       target1 = Target.new
       target1.actions << "woot"

--- a/spec/scram/concerns/holder_spec.rb
+++ b/spec/scram/concerns/holder_spec.rb
@@ -68,31 +68,28 @@ module Scram
       expect(model_policy.model?).to be true
     end
 
-    # TODO: Investigate whether or not it is worth somehow "force" denying through policies. Consider removing policy-priority system, it is currently useless.
-    xit "prioritizes policies" do
+    it "prioritizes policies" do
+      # Allow zing and woot
       target1 = Target.new
       target1.actions << "woot"
       target1.actions << "zing"
-      target1.allow = false
 
       policy1 = Policy.new
       policy1.collection_name = TestModel.name # A misc policy for strings
       policy1.targets << target1
 
-
+      # Deny woot in higher priority policy
       target2 = Target.new
       target2.actions << "woot"
+      target2.allow = false
 
       policy2 = Policy.new
       policy2.collection_name = TestModel.name # A misc policy for strings
       policy2.priority = 1
       policy2.targets << target2
 
-      policy1.save
-      policy2.save
-
       user = SimpleHolder.new(policies: [policy1, policy2])
-      expect(user.can? :woot, TestModel.new).to be true
+      expect(user.can? :woot, TestModel.new).to be false
       expect(user.can? :donk, TestModel.new).to be false
       expect(user.can? :zing, TestModel.new).to be true
     end

--- a/spec/scram/concerns/holder_spec.rb
+++ b/spec/scram/concerns/holder_spec.rb
@@ -2,6 +2,12 @@ require "spec_helper"
 
 module Scram
   describe Scram::Holder do
+
+    it "cannot be used without an implementation" do
+      expect {UnimplementedHolder.new.policies}.to raise_error(NotImplementedError)
+      expect {UnimplementedHolder.new.scram_compare_value}.to raise_error(NotImplementedError)
+    end
+
     it "holds model permissions" do
       target = Target.new
       target.actions << "woot"
@@ -60,6 +66,35 @@ module Scram
       model_policy.save
 
       expect(model_policy.model?).to be true
+    end
+
+    # TODO: Investigate whether or not it is worth somehow "force" denying through policies. Consider removing policy-priority system, it is currently useless.
+    xit "prioritizes policies" do
+      target1 = Target.new
+      target1.actions << "woot"
+      target1.actions << "zing"
+      target1.allow = false
+
+      policy1 = Policy.new
+      policy1.collection_name = TestModel.name # A misc policy for strings
+      policy1.targets << target1
+
+
+      target2 = Target.new
+      target2.actions << "woot"
+
+      policy2 = Policy.new
+      policy2.collection_name = TestModel.name # A misc policy for strings
+      policy2.priority = 1
+      policy2.targets << target2
+
+      policy1.save
+      policy2.save
+
+      user = SimpleHolder.new(policies: [policy1, policy2])
+      expect(user.can? :woot, TestModel.new).to be true
+      expect(user.can? :donk, TestModel.new).to be false
+      expect(user.can? :zing, TestModel.new).to be true
     end
 
   end

--- a/spec/scram/concerns/holder_spec.rb
+++ b/spec/scram/concerns/holder_spec.rb
@@ -36,6 +36,7 @@ module Scram
       target.conditions = {:equals => {:owner => "*holder"}}
       policy.save
       expect(dude.can? :woot, TestModel.new(owner: "Mr. Holder Guy")).to be true
+      expect(dude.can? :woot, TestModel.new(owner: "Mr. Holder Dude")).to be false
 
     end
 
@@ -52,6 +53,7 @@ module Scram
 
       dude = SimpleHolder.new(policies: [policy]) # This is a test holder
       expect(dude.can? :woot, :donk).to be true
+      expect(dude.can? :woot, :donkers).to be false
     end
 
     it "differentiates model and string policies" do

--- a/spec/scram/dsl_spec.rb
+++ b/spec/scram/dsl_spec.rb
@@ -21,6 +21,12 @@ module Scram
       owner_retrieval_condition = SimpleDSLImplementation.scram_conditions[:owner]
       expect(owner_retrieval_condition.call(test)).to eq("bob")
     end
+
+    it "handles retrieval of condition methods" do
+      test = SimpleDSLImplementation.new
+      test.owner = "bob"
+      expect(test.send("*owner")).to eq("bob")
+    end
   end
 
   describe Scram::DSL::Definitions do

--- a/spec/scram/policy_spec.rb
+++ b/spec/scram/policy_spec.rb
@@ -22,7 +22,7 @@ module Scram
 
       policy.save
 
-      expect(policy.can? nil, :woot, TestModel.new).to be true
+      expect(policy.can? nil, :woot, TestModel.new).to be :allow
     end
   end
 end

--- a/spec/scram/test_implementations/simple_aggregate_holder.rb
+++ b/spec/scram/test_implementations/simple_aggregate_holder.rb
@@ -1,6 +1,10 @@
 require "scram/concerns/aggregate_holder"
 
 module Scram
+  class UnimplementedAggregateHolder
+    include AggregateHolder
+  end
+
   class SimpleAggregateHolder
     include AggregateHolder
 

--- a/spec/scram/test_implementations/simple_aggregate_holder.rb
+++ b/spec/scram/test_implementations/simple_aggregate_holder.rb
@@ -1,0 +1,17 @@
+require "scram/concerns/aggregate_holder"
+
+module Scram
+  class SimpleAggregateHolder
+    include AggregateHolder
+
+    attr_accessor :aggregates
+
+    def initialize(aggregates: [])
+        @aggregates = aggregates
+    end
+
+    def scram_compare_value
+      "Mr. Aggregate Holder Guy"
+    end
+  end
+end

--- a/spec/scram/test_implementations/simple_holder.rb
+++ b/spec/scram/test_implementations/simple_holder.rb
@@ -1,6 +1,10 @@
 require "scram/concerns/holder"
 
 module Scram
+  class UnimplementedHolder
+    include Holder
+  end
+
   class SimpleHolder
     include Holder
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require "scram/test_implementations/simple_holder"
+require "scram/test_implementations/simple_aggregate_holder"
 require "scram/test_implementations/test_model"
 
 Mongoid.load!('./spec/config/mongoid.yml', :test)


### PR DESCRIPTION
Adds the aggregate system (branch based off aggregate stuff), uses symbols to represent abstaining targets and policies, cleans up code (and adds comments), fixes method missing in condition DSL.
